### PR TITLE
Added environment_nested plugin

### DIFF
--- a/docs/plugins/environment_nested.md
+++ b/docs/plugins/environment_nested.md
@@ -1,0 +1,18 @@
+# Environment Nested Plugin
+If you add `environment_nested` to your list of data sources in `common.yaml`, you'll be able to create or overwrite nested configuration variables.
+
+```yaml
+data_sources: [ "defaults", "file", "environment_nested" ]
+template_sources: [ "file" ]
+
+defaults:
+  global:
+    restapi:
+      server:
+        port: 80
+```
+
+Setting environment variable `restapi_server_port=8080` will overwrite value `80` from defaults.
+
+To overwrite large structures it's probably easier to use `environment_json`.
+

--- a/docs/plugins/index.md
+++ b/docs/plugins/index.md
@@ -7,6 +7,7 @@ In addition to specifying values in YAML environment files, there are other plug
  * [Defaults](defaults.md) : Make use of default values across your environments and templates - this can help avoid repeated definitions and makes for more efficient configuration.
  * [Environment variables](environment.md) : Make use of environment variables in your templates.
  * [JSON environment variables](environment_json.md) : Use complex JSON data structures from the environment in your templates. See [http://www.markround.com/blog/2014/10/17/building-dynamic-docker-images-with-json-and-tiller-0-dot-1-4/](http://www.markround.com/blog/2014/10/17/building-dynamic-docker-images-with-json-and-tiller-0-dot-1-4/) for some practical examples.
+ * [Nested environment variables](environment_nested.md) : Use environment variables `a_b_c=value` to build nested variables like `a['b']['c']`.
  * [External files](external_file.md) : Load external JSON or YAML files, and use their contents in your templates.
  * [HTTP plugins](http.md) : These plugins let you retrieve your templates and values from a HTTP server
  * [Random data](random.md) : Simple wrapper to provide random values to your templates.

--- a/features/environment_nested.feature
+++ b/features/environment_nested.feature
@@ -1,0 +1,29 @@
+Feature: Configure tiller with nested environment variables
+
+  Scenario: Import environment variable using string data type
+    Given I use a fixture named "environment_nested"
+    And I set the environment variables to:
+      | variable      | value                      |
+      | my_nested_var | http://www.somecompany.com |
+    When I successfully run `tiller -b . -v -n`
+    Then a file named "test.txt" should exist
+    And the file "test.txt" should contain "test_var: http://www.somecompany.com"
+
+  Scenario: Import environment variable using numeric data type
+    Given I use a fixture named "environment_nested"
+    And I set the environment variables to:
+      | variable      | value      |
+      | my_nested_var | 1234       |
+    When I successfully run `tiller -b . -v -n`
+    Then a file named "test.txt" should exist
+    And the file "test.txt" should contain "test_var: 1234"
+
+  Scenario: Import environment variable using boolean data type
+    Given I use a fixture named "environment_nested"
+    And I set the environment variables to:
+      | variable      | value      |
+      | my_nested_var | true       |
+    When I successfully run `tiller -b . -v -n`
+    Then a file named "test.txt" should exist
+    And the file "test.txt" should contain "test_var: true"
+

--- a/features/fixtures/environment_nested/common.yaml
+++ b/features/fixtures/environment_nested/common.yaml
@@ -1,0 +1,8 @@
+---
+data_sources: [ "defaults", "environment_nested" ]
+template_sources: [ "file" ]
+
+defaults:
+
+  test.erb:
+    target: test.txt

--- a/features/fixtures/environment_nested/templates/test.erb
+++ b/features/fixtures/environment_nested/templates/test.erb
@@ -1,0 +1,1 @@
+test_var: <%= my['nested']['var'] %>

--- a/lib/tiller/data/environment_nested.rb
+++ b/lib/tiller/data/environment_nested.rb
@@ -1,0 +1,18 @@
+require 'tiller/datasource'
+
+class EnvironmentNestedDataSource < Tiller::DataSource
+
+  def global_values
+    values = Hash.new
+    ENV.each do |k, v|
+      begin
+        v = YAML.load(v)  # helper to get real data type instead of string
+        values.deep_merge!(k.split('_').reverse.inject(v) { |a, n| { n => a } })
+      rescue
+        Tiller::log.debug("Environment variable #{k} with value #{v} could not be unfolded (ignored)")
+      end
+    end
+    values
+  end
+
+end

--- a/tiller.gemspec
+++ b/tiller.gemspec
@@ -33,6 +33,7 @@ Gem::Specification.new do |s|
     lib/tiller/data/http.rb
     lib/tiller/data/environment.rb
     lib/tiller/data/environment_json.rb
+    lib/tiller/data/environment_nested.rb
     lib/tiller/data/external_file.rb
     lib/tiller/data/random.rb
     lib/tiller/data/defaults.rb


### PR DESCRIPTION
Adding `environment_nested` to the list of datasources and setting environment variable `restapi_server_port=8080` will overwrite value `80` from _defaults_.

```yaml
data_sources: [ "defaults", "file", "environment_nested" ]
template_sources: [ "file" ]

defaults:
  global:
    restapi:
      server:
        port: 80
```
