### PR TITLE
Refactor the Vault plugin to work in 'flex_mode', with documentation

### DIFF
--- a/docs/plugins/vault.md
+++ b/docs/plugins/vault.md
@@ -52,8 +52,8 @@ vault:
 
 ## Authentication
 
-Vault requires a token in order to connect to it. If you omit the token parameter, Tiller will look for it in your `~/.vault-token` file (which is created automatically when vault is started in dev mode). 
- 
+Vault requires a token in order to connect to it. If you omit the token parameter, Tiller will look for it in your `~/.vault-token` file (which is created automatically when vault is started in dev mode).
+
 
 ```yaml
 vault:
@@ -64,7 +64,7 @@ vault:
 # Paths
 You can use any K/V hierarchy inside Vault, but the default is expected to look like the following:
 
-Since Vault stores documents in JSON with a body like: 
+Since Vault stores documents in JSON with a body like:
 
 ```json
 {
@@ -72,7 +72,7 @@ Since Vault stores documents in JSON with a body like:
 }
 ```
 
-by default Tiller will assume that the key name is `content`, however it is configurable with `json_key_name` parameter. If you want it to be stored, for example, as 
+by default Tiller will assume that the key name is `content`, however it is configurable with `json_key_name` parameter. If you want it to be stored, for example, as
 
 ```json
 {
@@ -80,7 +80,7 @@ by default Tiller will assume that the key name is `content`, however it is conf
 }
 ```
 
-you can configure Tiller as follows: 
+you can configure Tiller as follows:
 
 ```yaml
 vault:
@@ -106,7 +106,7 @@ vault:
 	 	 ├── values
 	 	 │   ├── production (keys and values for the 'production' environment)
 	 	 │   │       ├ template1.erb
-	 	 │   │       │     ├── some_key 
+	 	 │   │       │     ├── some_key
 	 	 │   │       │     ├── some_other_key
      	 │   │       ├ template2.erb
 	 	 │   │       │     ├── some_key
@@ -154,3 +154,37 @@ This is a global value : <%= some_key_for_all_environments %>
 This should only be present in production : <%= some_key_only_for_production_environment %>
 ```
 
+# Flex Mode
+
+If you would like to be more precise with your Vault paths, or simply want to access all of the Key/Value pairs in a single Vault document rather than just a single key, you can use `flex_mode`:
+
+```yaml
+data_sources: [ "vault" , "file" ]
+template_sources: [ "file" ]
+dynamic_values: true
+
+vault:
+  url: 'http://127.0.0.1:8200'
+  flex_mode: true
+  values:
+    foo: 'secret/custom/foo'
+    custom: 'secret/custom'
+
+environments:
+  development:
+    test.erb:
+      target: test.txt
+        vault:
+          foo: 'secret/%e/foo'
+          dynamic_foo: 'secret/<%= environment %>/foo'
+
+test.erb:
+  vault:
+    all_foo: 'secret/<%= environment %>/foo'
+```
+
+You can also use specify a list path in Vault to be used in a mapping, and the plugin will map the listed keys into a symbolized hash.
+
+**NOTE:** Vault cannot be used as a template source when in `flex_mode`. All `values` will be mapped to globals.
+
+You can also make template-specific Vault mappings within the `environments` namespace or top-level namespace, as described above. The environment-specific Vault mappings will override the top-level ones.

--- a/docs/plugins/vault.md
+++ b/docs/plugins/vault.md
@@ -52,7 +52,7 @@ vault:
 
 ## Authentication
 
-Vault requires a token in order to connect to it. If you omit the token parameter, Tiller will look for it in your `~/.vault-token` file (which is created automatically when vault is started in dev mode).
+Vault requires a token in order to connect to it. If you omit the token parameter, Tiller will first look in the `VAULT_TOKEN` environment variable, and then look for it in your `~/.vault-token` file (which is created automatically when vault is started in dev mode).
 
 
 ```yaml

--- a/features/support/vault_test_data.rb
+++ b/features/support/vault_test_data.rb
@@ -40,6 +40,9 @@ This is a per-environment global : <%= vault_per_env %>}
   # Populate templates content
   Vault.logical.write('/secret/tiller/templates/template1.erb', content: template1)
   Vault.logical.write('/secret/tiller/templates/template2.erb', content: template2)
+  # Populate custom foo bar values for flex mode
+  Vault.logical.write('/secret/custom/foo', value: 'bar')
+  Vault.logical.write('/secret/development/foo', value: 'devbar')
 end
 
 if ! defined?(Cucumber)

--- a/lib/tiller/data/vault.rb
+++ b/lib/tiller/data/vault.rb
@@ -13,6 +13,7 @@ class VaultDataSource < Tiller::DataSource
       globals = {}
       Tiller::log.debug("#{self} : In Flex Mode: Fetching all defined paths under values")
       @vault_config['values'].each do |key, path|
+        next unless path
         Tiller::log.debug("#{self} : Fetching values in #{path} into the #{key} variable")
         path = "/#{path}" if path[0] != '/'
         path = interpolate(path)

--- a/lib/tiller/data/vault.rb
+++ b/lib/tiller/data/vault.rb
@@ -9,26 +9,58 @@ class VaultDataSource < Tiller::DataSource
 
   def global_values
     return {} unless Tiller::config.has_key?('vault')
-    path = interpolate("#{@vault_config['values']['global']}")
-    Tiller::log.debug("#{self} : Fetching globals from #{path}")
-    globals = get_values(path)
+    if @vault_config['flex_mode']
+      globals = {}
+      Tiller::log.debug("#{self} : In Flex Mode: Fetching all defined paths under values")
+      @vault_config['values'].each do |key, path|
+        Tiller::log.debug("#{self} : Fetching values in #{path} into the #{key} variable")
+        path = "/#{path}" if path[0] != '/'
+        path = interpolate(path)
+        globals[key] = get_values(path)
+      end
+      globals
+    else
+      path = interpolate("#{@vault_config['values']['global']}")
+      Tiller::log.debug("#{self} : Fetching globals from #{path}")
+      globals = get_values(path)
 
-    # Do we have per-env globals ? If so, merge them
-    path = interpolate("#{@vault_config['values']['per_env']}")
-    Tiller::log.debug("#{self} : Fetching per-environment globals from #{path}")
-    globals.deep_merge!(get_values(path))
+      # Do we have per-env globals ? If so, merge them
+      path = interpolate("#{@vault_config['values']['per_env']}")
+      Tiller::log.debug("#{self} : Fetching per-environment globals from #{path}")
+      globals.deep_merge!(get_values(path))
+    end
   end
 
   def values(template_name)
     return {} unless Tiller::config.has_key?('vault')
-    path = interpolate("#{@vault_config['values']['template']}", template_name)
-    Tiller::log.debug("#{self} : Fetching template values from #{path}")
-    get_values(path)
+    if @vault_config['flex_mode']
+      # Merge configs of the template and environment, subsequently
+      template_config = Tiller::config[template_name] || {}
+      if Tiller::config.has_key?('environments') && Tiller::config['environments'].has_key?(Tiller::config[:environment]) && Tiller::config['environments'][Tiller::config[:environment]].has_key?(template_name)
+        template_config.deep_merge!(Tiller::config['environments'][Tiller::config[:environment]][template_name])
+      end
+      return {} unless template_config.has_key?('vault')
+      values = {}
+      template_config['vault'].each do |key, path|
+        path = "/#{path}" if path[0] != '/'
+        # We want to make Vault compatible with dynamic values here
+        path = Tiller::render(path, direct_render: true) if Tiller::config.assoc('dynamic_values')
+        path = interpolate(path)
+        Tiller::log.debug("#{self} : Fetching values in #{path} into the #{key} variable")
+        values[key] = get_values(path)
+      end
+      values
+    else
+      path = interpolate("#{@vault_config['values']['template']}", template_name)
+      Tiller::log.debug("#{self} : Fetching template values from #{path}")
+      get_values(path)
+    end
   end
 
 
   def target_values(template_name)
     return {} unless Tiller::config.has_key?('vault')
+    return {} if @vault_config['flex_mode']
     path = interpolate("#{@vault_config['values']['target']}", template_name)
     Tiller::log.debug("#{self} : Fetching template target values from #{path}")
     get_values(path)
@@ -38,18 +70,37 @@ class VaultDataSource < Tiller::DataSource
   # Helper method, not used by DataSource API
   def get_values(path)
     keys = nil
+    Tiller::log.debug("Trying Vault list with #{path}")
     Vault.with_retries(Vault::HTTPConnectionError, Vault::HTTPError) do |attempt, e|
-        Tiller::log.warn("#{self} : Received exception #{e} from Vault") if e
-        keys = Vault.logical.list(path)
+      Tiller::log.warn("#{self} : Received exception #{e} from Vault") if e
+      keys = Vault.logical.list(path)
     end
 
     values = {}
-    if keys.is_a? Array
+    if keys.is_a?(Array) && keys.size > 0
       keys.each do |k|
         Tiller::log.debug("#{self} : Fetching value at #{path}/#{k}")
         Vault.with_retries(Vault::HTTPConnectionError, Vault::HTTPError) do |attempt, e|
-            Tiller::log.warn("#{self} : Received exception #{e} from Vault") if e
-            values[k] = Vault.logical.read(File.absolute_path(k,path)).data[@vault_config['json_key_name']]
+          Tiller::log.warn("#{self} : Received exception #{e} from Vault") if e
+          Tiller::log.debug("Actual Vault Path: #{File.absolute_path(k,path)}")
+          vdata = Vault.logical.read(File.absolute_path(k,path)).data
+          if @vault_config['flex_mode']
+            values[k.to_sym] = vdata
+          else
+            values[k] = vdata[@vault_config['json_key_name']]
+          end
+        end
+      end
+      values
+    elsif @vault_config['flex_mode']
+      Tiller::log.debug("#{path} is likely a Vault document, retrieving values for them")
+      Vault.with_retries(Vault::HTTPConnectionError, Vault::HTTPError) do |attempt, e|
+        Tiller::log.warn("#{self} : Received exception #{e} from Vault") if e
+        vault_data = Vault.logical.read(path)
+        if vault_data && (data = vault_data.data) && data.is_a?(Hash)
+          values = data
+        else
+          Tiller::log.warn("No values found at #{path}")
         end
       end
       values

--- a/lib/tiller/vault.rb
+++ b/lib/tiller/vault.rb
@@ -19,7 +19,7 @@ module Tiller::VaultCommon
 
     # Sanity checks
     ['url'].each {|c| raise "Missing Vault configuration #{c}" unless @vault_config.has_key?(c)}
-    raise "Missing Vault token" if !((VAULT_TOKEN_FILE && File.exists? VAULT_TOKEN_FILE) || @vault_config['token'] || ENV['VAULT_TOKEN'])
+    raise "Missing Vault token" if !((VAULT_TOKEN_FILE && File.exists?(VAULT_TOKEN_FILE)) || @vault_config['token'] || ENV['VAULT_TOKEN'])
 
     Vault.configure do |config|
         # The address of the Vault server

--- a/lib/tiller/vault.rb
+++ b/lib/tiller/vault.rb
@@ -3,7 +3,7 @@ require 'pp'
 require 'tiller/defaults'
 require 'tiller/util'
 
-VAULT_TOKEN_FILE = "#{Dir.home}/.vault-token"
+VAULT_TOKEN_FILE = ENV.key?('HOME') ? "#{Dir.home}/.vault-token" : nil
 
 module Tiller::VaultCommon
   def setup
@@ -19,14 +19,14 @@ module Tiller::VaultCommon
 
     # Sanity checks
     ['url'].each {|c| raise "Missing Vault configuration #{c}" unless @vault_config.has_key?(c)}
-    raise "Missing Vault token" if !(File.exists? VAULT_TOKEN_FILE || @vault_config['token'])
+    raise "Missing Vault token" if !((VAULT_TOKEN_FILE && File.exists? VAULT_TOKEN_FILE) || @vault_config['token'] || ENV['VAULT_TOKEN'])
 
     Vault.configure do |config|
         # The address of the Vault server
         config.address = @vault_config['url']
 
         # The token to authenticate to Vault
-        config.token = @vault_config['token'] || File.read(VAULT_TOKEN_FILE)
+        config.token = @vault_config['token'] || ENV['VAULT_TOKEN'] || File.read(VAULT_TOKEN_FILE)
 
         config.ssl_verify = @vault_config['ssl_verify']
         config.ssl_pem_file = @vault_config['ssl_pem_file'] if @vault_config.has_key?(:ssl_pem_file)


### PR DESCRIPTION
As I chatted on Gitter about, I have a different way that I'd like to use Vault, specifically being able to take a single path and reuse it between different environments instead of having to replicate the value into template-specific namespaces.

Here is my Pull Request for such a "mode" to do this. I added test cases, documentation, and kept it backwards compatible with the existing plugin implementation. I was trying to go for a very unbiased approach. Here's a sample config:

```
data_sources: [ "vault" , "file", "environment" ]
template_sources: [ "file" ]

dynamic_values: true
vault:
  url: 'http://127.0.0.1:8200'
  flex_mode: true
  values:
    foo: 'secret/custom/foo'
    custom: 'secret/custom'
    global_dev_foo: 'secret/%e/foo'

environments:
  development:
    test.erb:
      target: test.txt
      vault:
        dev_foo: 'secret/<%= environment %>/foo'

test.erb:
  vault:
    all_foo: 'secret/<%= environment %>/foo'
```

Given a Vault with:
```
Vault.logical.write('/secret/custom/foo', value: 'bar')
Vault.logical.write('/secret/development/foo', value: 'devbar')
```

You can create a `test.erb` file with various usages:

```
foo_value: <%= foo[:value] %>
custom_foo_value: <%= custom[:foo][:value] %>
global_dev_foo_value: <%= global_dev_foo[:value] %>
local_dev_foo_value: <%= dev_foo[:value] %>
all_foo_value: <%= all_foo[:value] %>
```

Note I also made it possible to use dynamic values in a Vault template path, since I would like to be able to use environment variables to dictate what Vault paths to access. For example, I run different localized versions of my application, so I want to set a `SITE_COUNTRY` environment variable to access a `secret/country/<%= env_site_country %>` list of values.

I'm not fully aware of the design philosophy of Tiller so I'm sure you'll have some feedback. The way I've designed the plugin here is exactly how I would like Tiller to work for me, but this may not be the same for everyone else.