### PR TITLE
Sort default files before loading them

### DIFF
--- a/lib/tiller/data/defaults.rb
+++ b/lib/tiller/data/defaults.rb
@@ -26,7 +26,7 @@ class DefaultsDataSource < Tiller::DataSource
     # If we have YAML files in defaults.d, also merge them
     # We do this even if the main defaults were loaded from the v2 format config
     if File.directory? defaults_dir
-      Dir.glob(File.join(defaults_dir,'*.yaml')).each do |d|
+      Dir.glob(File.join(defaults_dir,'*.yaml')).sort().each do |d|
         yaml = YAML.load(open(d))
         Tiller::log.debug("Loading defaults from #{d}")
         @defaults_hash.deep_merge!(yaml) if yaml != false


### PR DESCRIPTION
If we want to load files using the defaults.d feature, we will probably want them to be sorted alphabetically, so we can guarantee the order of the merge.