### PR TITLE
Deep merge dynamic_values

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ group :development do
   gem 'rake'
   gem 'rspec'
   gem 'aruba', '~> 0.13.0'
+  gem 'cucumber', '~> 2.4.0'
   gem 'httpclient'
   gem 'oj'
   gem 'zk'

--- a/bin/tiller
+++ b/bin/tiller
@@ -212,7 +212,7 @@ module Tiller
             # Proper Ruby voodoo here.
             # See http://stackoverflow.com/questions/19304135/deep-nest-a-value-into-a-hash-given-a-path-array for
             # explanation.
-            tiller.merge!((path + [parsed_value]).reverse.reduce { |s,e| { e => s } })
+            tiller.deep_merge!((path + [parsed_value]).reverse.reduce { |s,e| { e => s } })
           end
         end
         target_values.each do |key ,value|


### PR DESCRIPTION
I think there's a problem when using dynamic_values with objects in config. 
in my yaml I have something like

```
someKey:
    someOtherKey2:
        key: value2
    someOtherKey:
        key: value
        key2: <%= Tiller::MyHelper.method() -%>
```

but when it merges the results, key dissapears, and only key2 stays. 

For instance, if  Tiller::MyHelper.method() => RESULT:
```"someKey"=>{"someOtherKey2"=>{"key"=>"value2"}, "someOtherKey"=>{"key"=>"value", "key2"=>"<%= Tiller::MyHelper.method() -%>"}}```

Gets solved to:
```"someKey"=>{"someOtherKey"=>{"key2"=>"RESULT"}}```

With the change, I get this (which is more desireable):
```"someKey"=>{"someOtherKey2"=>{"key"=>"value2"}, "someOtherKey"=>{"key"=>"value", "key2"=>"RESULT"}}```
