### PR TITLE
stop using deprecated File/Dir.exists?

### DIFF
--- a/bin/tiller
+++ b/bin/tiller
@@ -58,7 +58,7 @@ module Tiller
 
     # Is there a common.yaml ? If so, load that first
     common_file = File.join(config[:tiller_base], 'common.yaml')
-    if File.exists?(common_file)
+    if File.exist?(common_file)
       config.merge!(YAML.load(open(common_file)))
       config_loaded = true
     end
@@ -242,7 +242,7 @@ module Tiller
     filename = target_values['target']
 
     # MD5 checksum of templates
-    if config['md5sum'] && File.exists?(filename)
+    if config['md5sum'] && File.exist?(filename)
       template_md5 = Digest::MD5.hexdigest(parsed_template)
       log.debug("MD5 of #{template} is #{template_md5}")
       file_md5 = Digest::MD5.hexdigest(File.read(filename))

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,4 +1,6 @@
 # 1.x
+  * 1.5.1 (07/Nov/2024)
+    * Updated File/Dir.exists? to exist? due to exists? being removed from Ruby 3.2+
   * 1.5.0 (02/Feb/2019)
     * Fixed [Issue #48](https://github.com/markround/tiller/issues/48). MD5 checksums were incorrectly calculated as a newline character was getting added. Also modified --no-exec flag so that it also prevents any exec_on_write commands running. Thanks again [EugenMayer](https://github.com/EugenMayer) for the comments.
 

--- a/features/step_definitions/consul.rb
+++ b/features/step_definitions/consul.rb
@@ -26,7 +26,7 @@ end
 
 
 Given(/^an empty consul data directory$/) do
-  if Dir.exists?(CONSUL_DATA_DIR)
+  if Dir.exist?(CONSUL_DATA_DIR)
     puts "Directory #{CONSUL_DATA_DIR} exists, deleting"
     FileUtils.rm_r(CONSUL_DATA_DIR)
   else

--- a/features/step_definitions/vault.rb
+++ b/features/step_definitions/vault.rb
@@ -5,7 +5,7 @@ require 'pp'
 # Vault configuration
 VAULT_TOKEN_FILE = "#{Dir.home}/.vault-token"
 # So that Cucumber does not complain that the file does not exist
-File.open(VAULT_TOKEN_FILE, "w+"){|file| file.write(".")} if !File.exists? VAULT_TOKEN_FILE
+File.open(VAULT_TOKEN_FILE, "w+"){|file| file.write(".")} if !File.exist? VAULT_TOKEN_FILE
 
 Vault.configure do |config|
   config.address = "http://127.0.0.1:8200"
@@ -26,7 +26,7 @@ When(/^I have downloaded vault "(.+)" to "(.+)"$/) do |version, path|
 end
 
 And (/^a token should be created$/) do
-  test = File.exists? VAULT_TOKEN_FILE
+  test = File.exist? VAULT_TOKEN_FILE
   expect(test).to be_truthy
 end
 

--- a/features/step_definitions/zip.rb
+++ b/features/step_definitions/zip.rb
@@ -6,7 +6,7 @@ When(/^I have unzipped the archive "(.+)"$/) do |archive|
     zip_file.each do |entry|
       dest = File.join(dirname, entry.name)
       puts "Extracting #{entry.name} to #{dest}"
-      if File.exists?(dest)
+      if File.exist?(dest)
         puts "File exists, skipping..."
       else
         entry.extract(dest)

--- a/lib/tiller/vault.rb
+++ b/lib/tiller/vault.rb
@@ -19,7 +19,7 @@ module Tiller::VaultCommon
 
     # Sanity checks
     ['url'].each {|c| raise "Missing Vault configuration #{c}" unless @vault_config.has_key?(c)}
-    raise "Missing Vault token" if !((VAULT_TOKEN_FILE && File.exists?(VAULT_TOKEN_FILE)) || @vault_config['token'] || ENV['VAULT_TOKEN'])
+    raise "Missing Vault token" if !((VAULT_TOKEN_FILE && File.exist?(VAULT_TOKEN_FILE)) || @vault_config['token'] || ENV['VAULT_TOKEN'])
 
     Vault.configure do |config|
         # The address of the Vault server


### PR DESCRIPTION
Ruby 3.2 no longer has the `exists?` alias for File and Dir.